### PR TITLE
ISSUE-11: Auto deploy latest docker image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,19 @@
+name: Publish Docker image
+on:
+  release:
+    types: [published]
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Push to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          repository: CodingGarden/entropychat.app/entropychat.api
+          tag_with_ref: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Publish Docker image
 on:
+  push:
+    branches:
+      - master
   release:
     types: [published]
 jobs:
@@ -9,9 +12,6 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
-      - run: |
-          cd server
-          pwd
       - name: Push to GitHub Packages
         uses: docker/build-push-action@v1
         with:
@@ -19,5 +19,5 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           path: server/.
           registry: docker.pkg.github.com
-          repository: ${{ github.repository}}/entropychat.app/entropychat.api
+          repository: nicomigueles/entropychat.app/entropychat.api
           tag_with_ref: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,5 @@
 name: Publish Docker image
 on:
-  push:
-    branches:
-      - master
   release:
     types: [published]
 jobs:
@@ -22,5 +19,5 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           path: server/.
           registry: docker.pkg.github.com
-          repository: nicomigueles/entropychat.app/entropychat.api
+          repository: ${{ github.repository}}/entropychat.app/entropychat.api
           tag_with_ref: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+          path: server/.
           registry: docker.pkg.github.com
           repository: nicomigueles/entropychat.app/entropychat.api
           tag_with_ref: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,5 +19,5 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           path: server/.
           registry: docker.pkg.github.com
-          repository: nicomigueles/entropychat.app/entropychat.api
+          repository: codinggarden/entropychat.app/entropychat.api
           tag_with_ref: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Publish Docker image
 on:
+  push:
+    branches:
+      - master
   release:
     types: [published]
 jobs:
@@ -9,11 +12,14 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+      - run: |
+          cd server
+          pwd
       - name: Push to GitHub Packages
         uses: docker/build-push-action@v1
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: docker.pkg.github.com
-          repository: CodingGarden/entropychat.app/entropychat.api
+          repository: nicomigueles/entropychat.app/entropychat.api
           tag_with_ref: true


### PR DESCRIPTION
## Action to automatically deploy the docker image to Github

This should close #11 

### Action triggers:

**push** : branches : master
**release** :  types : published

### How taggin works:

> tag is the "version", ex: `docker.pkg.github.com/codinggarden/entropychat.app/entropychat.api:1.0.1`, 1.0.1 is the tag.

For pushes to a branch the reference will be `refs/heads/{branch-name}` and the tag will be `{branch-name}`. If `{branch-name}` is master then the tag will be `latest`.

For git tags the reference will be `refs/tags/{git-tag}` and the tag will be `{git-tag}`.

Examples:

|Git Reference|Image tag|
|---|---|
|`refs/heads/master`|`latest`|
|`refs/tags/v1.0.0`|`v1.0.0`|

Reference: https://github.com/docker/build-push-action/blob/master/README.md


I have tested the functionality in my fork.