### PR TITLE
Docker fix

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 
 COPY package*.json ./
 
-RUN npm install
+RUN npm ci && npm cache clean --force
 
 COPY . .
 

--- a/server/docker-compose.windows.yml
+++ b/server/docker-compose.windows.yml
@@ -20,8 +20,6 @@ services:
       - db
     volumes:
       - ./:/usr/src/app:cached
-      - npm_cache:/root/.npm:delegated
-      - node_modules:/app/node_modules:delegated
     ports:
       - ${PORT}:${PORT}
     environment:
@@ -36,6 +34,4 @@ services:
       MONGO_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD}
 
 volumes:
-  npm_cache:
-  node_modules:
   mongodb:

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -20,8 +20,6 @@ services:
       - db
     volumes:
       - ./:/usr/src/app:cached
-      - npm_cache:/root/.npm:delegated
-      - node_modules:/usr/src/app/node_modules:delegated
     ports:
       - ${PORT}:${PORT}
     environment:
@@ -34,7 +32,3 @@ services:
       MONGO_DB_NAME: ${MONGO_DB_NAME}
       MONGO_ROOT_USER: ${MONGO_ROOT_USER}
       MONGO_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD}
-
-volumes:
-  npm_cache:
-  node_modules:


### PR DESCRIPTION
There is no point mounting the node_modules as our Dockerfile tells docker to install all modules from our package.json, using the local ones instead of the ones in the container can cause problems.

Also replaced the install command with `npm ci` and added `&& npm cache clean --force` to not bloat the image with the cache after installation (as suggested by docd27 in the discord).

I have tested and the containers still spin up fine without mounting the node folders.

(My first ever PR on github so hopefully i didn't do it wrong 😛)