### PR TITLE
Fix docker so the app waits for mongo

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -10,7 +10,7 @@ RUN npm install
 
 COPY . .
 
-ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.2.1/wait /wait
+ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.7.3/wait /wait
 RUN chmod +x /wait
 
-CMD [ "/wait", "&&", "pm2-runtime", "start", "ecosystem.config.js" ]
+CMD /wait && pm2-runtime start ecosystem.config.js

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -10,4 +10,7 @@ RUN npm install
 
 COPY . .
 
-CMD [ "pm2-runtime", "start", "ecosystem.config.js" ]
+ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.2.1/wait /wait
+RUN chmod +x /wait
+
+CMD [ "/wait", "&&", "pm2-runtime", "start", "ecosystem.config.js" ]

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -12,7 +12,6 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD}
 
   api:
-    # TODO: wait for mongodb to be available...
     image: entropychat.api
     build: .
     restart: on-failure
@@ -25,6 +24,7 @@ services:
     ports:
       - ${PORT}:${PORT}
     environment:
+      WAIT_HOSTS: ${MONGO_HOST}:${MONGO_PORT}
       PORT: ${PORT}
       JWT_SECRET: ${JWT_SECRET}
       GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}


### PR DESCRIPTION
Sorry to hijack and fix the issue, but I had this problem before.

Now looking at the issue it has has nothing to do with waiting for `mongo` to start, but still you can see the implementation here.

It uses this implementation https://github.com/ufoscout/docker-compose-wait/